### PR TITLE
Add .gitattributes to force LF on shell/Node scripts (fixes Windows checkouts)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh  text eol=lf
+*.mjs text eol=lf


### PR DESCRIPTION
```markdown
   **Problem**

   On Windows with Git's default `core.autocrlf=true`, `tools/*.sh` is checked out
   with CRLF. bash reads the shebang as `#!/usr/bin/env bash\r` and appends `\r` to
   every token, so `scaffold.sh` fails on any invocation.

   **Reproduction** — fresh clone on Windows:

   ```
$ cat -A tools/scaffold.sh | head -1
#!/usr/bin/env bash^M$
```

   Running `sed -i 's/\r$//' tools/*.sh` is what makes it work — that's the only
   difference.

   **Fix**

   A two-line `.gitattributes` pinning `*.sh` and `*.mjs` to `eol=lf`. Scoped to the
   files an interpreter executes; no content changes and no diff elsewhere. Removes
   the need for every Windows user to run `dos2unix` after cloning.
   ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized line endings for shell script and module files to improve cross-platform consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->