### PR TITLE
docs: fix completion formula rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ attempts before replaying commands. Persist decisions and checkpoint before stop
 For a task $t$, Genesis treats completion as a conjunction of checks:
 
 $$
-\operatorname{Done}(t) \Rightarrow
-\operatorname{Active}(t) \land
-\operatorname{DependenciesDone}(t) \land
-\operatorname{ScopeValid}(t) \land
-\bigwedge_{g\in G_t}\operatorname{FreshProof}(g) \land
-\operatorname{RequiredReview}(t).
+\mathrm{Done}(t) \Rightarrow
+\mathrm{Active}(t) \land
+\mathrm{DependenciesDone}(t) \land
+\mathrm{ScopeValid}(t) \land
+\bigwedge_{g\in G_t}\mathrm{FreshProof}(g) \land
+\mathrm{RequiredReview}(t).
 $$
 
 Here $G_t$ is the set of mandatory gates, including at least one executable gate. Workflow approval is required for specification-first projects. Scope is enforced when declared and is required for autonomous execution. Independent human review is required above low risk.


### PR DESCRIPTION
Replace the unsupported operatorname macro with mathrm in the README completion formula. The equation and its meaning are unchanged. Checked the diff and confirmed all six unsupported macros were removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README’s completion-contract formula formatting for improved consistency.
  - The formula’s structure and meaning remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->