### PR TITLE
fix: make Genesis work on Windows

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,16 +15,29 @@ done
 
 BIN_DIR="${GENESIS_BIN_DIR:-$HOME/.local/bin}"
 BIN="$BIN_DIR/genesis"
+TARGET="$KIT_DIR/tools/genesis.mjs"
+MARKER="# installed by genesis-kit install.sh"
 mkdir -p "$BIN_DIR"
-if [[ -e "$BIN" && ! -L "$BIN" ]]; then
-  echo "Refusing to replace existing file: $BIN" >&2
-  exit 1
-fi
-if [[ -L "$BIN" && "$(readlink "$BIN")" != "$KIT_DIR/tools/genesis.mjs" ]]; then
+if [[ -L "$BIN" && "$(readlink "$BIN")" != "$TARGET" ]]; then
   echo "Refusing to replace existing link: $BIN" >&2
   exit 1
 fi
-ln -sfn "$KIT_DIR/tools/genesis.mjs" "$BIN"
+if [[ -e "$BIN" && ! -L "$BIN" ]] && ! grep -qF "$MARKER" "$BIN" 2>/dev/null; then
+  echo "Refusing to replace existing file: $BIN" >&2
+  exit 1
+fi
+ln -sfn "$TARGET" "$BIN" 2>/dev/null || true
+# genesis.mjs imports its siblings from tools/, so the entry point has to resolve back into the
+# kit. Where symlinks are unavailable ln -s copies the file instead of failing, and the detached
+# copy dies on its first import; write a shim in that case rather than ship the broken copy.
+if [[ ! -L "$BIN" ]]; then
+  rm -f "$BIN"
+  printf '#!/usr/bin/env bash
+%s
+exec node "%s" "$@"
+' "$MARKER" "$TARGET" > "$BIN"
+  chmod +x "$BIN"
+fi
 
 echo "Genesis installed offline."
 echo "  CLI: $BIN"

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,15 @@ if [[ -L "$BIN" && "$(readlink "$BIN")" != "$TARGET" ]]; then
   echo "Refusing to replace existing link: $BIN" >&2
   exit 1
 fi
-if [[ -e "$BIN" && ! -L "$BIN" ]] && ! grep -qF "$MARKER" "$BIN" 2>/dev/null; then
+# A shim this script wrote is ours to replace; anything else at that path is not. Match the whole
+# three-line shape, not just the marker, which an unrelated file could happen to contain anywhere.
+installed_shim() {
+  local first second third extra
+  [[ -f $1 ]] || return 1
+  { IFS= read -r first && IFS= read -r second && IFS= read -r third && ! IFS= read -r extra; } < "$1" || return 1
+  [[ $first == '#!/usr/bin/env bash' && $second == "$MARKER" && $third == 'exec node '* ]]
+}
+if [[ -e "$BIN" && ! -L "$BIN" ]] && ! installed_shim "$BIN"; then
   echo "Refusing to replace existing file: $BIN" >&2
   exit 1
 fi
@@ -32,10 +40,9 @@ ln -sfn "$TARGET" "$BIN" 2>/dev/null || true
 # copy dies on its first import; write a shim in that case rather than ship the broken copy.
 if [[ ! -L "$BIN" ]]; then
   rm -f "$BIN"
-  printf '#!/usr/bin/env bash
-%s
-exec node "%s" "$@"
-' "$MARKER" "$TARGET" > "$BIN"
+  # The target is interpolated into shell source, so quote it with %q. Left bare, a kit directory
+  # containing $, ` or a quote would break the launcher or be expanded as a command on every run.
+  printf "#!/usr/bin/env bash\n%s\nexec node %q \"\$@\"\n" "$MARKER" "$TARGET" > "$BIN"
   chmod +x "$BIN"
 fi
 

--- a/tools/query.mjs
+++ b/tools/query.mjs
@@ -3,6 +3,7 @@
 // context packet can reuse exactly the same answers the CLI gives.
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const cache = new Map();
 // Adjacency, added once so every helper can assume it. Exported because the panel parses the
@@ -281,6 +282,6 @@ function main(argv) {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try { main(process.argv.slice(2)); } catch (error) { console.error(error.message); process.exit(1); }
 }


### PR DESCRIPTION
Two silent defects make the kit non-functional on Windows. Neither reports an error where it fails, so both look like an empty index rather than a bug. One commit each.

Verified on Windows 11, Node v24.16.0 x64, Git Bash (GNU bash 5.3.15, `x86_64-pc-cygwin`).

## `fix(query): run the CLI on Windows, where argv paths are not URLs`

`tools/query.mjs:284` compared `import.meta.url` against a hand-built `` `file://${process.argv[1]}` ``. On Windows `argv[1]` is a native path, so that produces `file://C:\kit\tools\query.mjs` while Node reports `file:///C:/kit/tools/query.mjs`. The guard was never true, `main()` never ran, and the process exited `0` having printed nothing.

`genesis.mjs:704` spawns this file as a subprocess, so `genesis query` was dead too — every structural question answered with silence and a success code. That matters most for `genesis query . impact PATH`, the pre-edit blast-radius check named in the operating contract, the generated kickoff, the phase instruction in every packet and all five recipes: empty output there reads as "nothing depends on this file".

```diff
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
```

`pathToFileURL` produces the form Node itself uses. `argv[1]` is checked because it is absent under `--eval`. This is the only file in `tools/` with the pattern.

**Tests:** none added. Four CLI tests in `tests/query.test.mjs` already fail on Windows with `SyntaxError: Unexpected end of JSON input` from parsing empty stdout, and pass after this change — they were already the regression test, they just never ran on a platform that could fail them.

## `fix(install): install a launcher that can start on Windows`

Git Bash without Developer Mode cannot create symlinks, and `ln -s` **copies the file instead of failing**. `install.sh` exited 0 and printed `Genesis installed offline.`, having left a detached copy of `genesis.mjs` at `~/.local/bin/genesis`.

That copy is not equivalent to a link. `genesis.mjs` imports `./query.mjs` and `./dashboard.mjs`, which resolve against `~/.local/bin/`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'C:\Users\<user>\.local\bin\query.mjs'
imported from C:\Users\<user>\.local\bin\genesis
```

Every invocation failed, `--help` included. The existing guards then made it unrecoverable: the orphan is a regular file with no marker, so re-running the installer hit `Refusing to replace existing file` and could not repair its own output.

The fix keeps the symlink where symlinks work, verifies one was actually created, and writes a shim where it was not. The shim execs the kit copy, so sibling imports resolve and the CLI still tracks `git pull` exactly as the symlink did. It carries a marker comment so the installer can replace its own output, while the guard still refuses a genuinely foreign file at that path.

**Verified:**

| Case | Result |
| --- | --- |
| Fresh install into an empty `GENESIS_BIN_DIR` | shim written, `genesis --help` runs |
| Re-run over the installer's own shim | replaced, no refusal |
| Foreign file at `$BIN` | `Refusing to replace existing file`, preserved |
| `genesis query <repo> callers 'src/util.ts#helper' --json` | returns the expected JSON |

## Test status on Windows

`npm test` was run on unmodified `9c13913` and again with these commits. Five tests fail **identically in both runs** — they are pre-existing Windows failures, not regressions from this PR:

| Test | File | Cause |
| --- | --- | --- |
| `installer is offline, idempotent, and installs Genesis plus Ponytail...` | `integration.test.mjs:21` | `spawnSync ... install.sh EFTYPE` — Windows cannot exec a `.sh` directly |
| `legacy scaffold delegates to v2 init without persisting removed options` | `integration.test.mjs` | not investigated |
| `internal symlink inputs work through repository aliases and stale with their target` | `autonomy.test.mjs` | needs real symlinks |
| `live writers cannot have their attempt stolen by recovery` | `autonomy.test.mjs` | not investigated |
| `a failing python3 costs symbols, not whole files` | `graphizer.test.mjs` | not investigated |

The four query tests named above are the only ones this PR changes, from failing to passing.

One thing worth flagging on the installer test: it dies at line 25 on Windows and never reaches its assertions, but if you ever make it runnable there, `assert.ok(lstatSync(join(bin, 'genesis')).isSymbolicLink())` at line 31 will need relaxing. On a platform without symlinks the shim is deliberately not one. Line 32 already asserts the contract that matters — that the installed launcher runs and prints usage — so line 31 pins the mechanism rather than the outcome. I left it alone here rather than widen the diff; say the word and I will.

## Scope

No behavior change on Linux or macOS: the symlink path is attempted first and taken whenever symlinks are available, and the query guard resolves identically there. No state contract, schema or context-packet change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI installation reliability when symbolic links cannot be created.
  * Ensured installed command shims correctly locate and execute the CLI.
  * Improved direct CLI execution detection for file paths containing spaces or special characters.
  * Prevented unrelated existing files from being mistaken for installer-managed command shims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->