### PR TITLE
feat: resolve Python imports against declared source roots

### DIFF
--- a/tests/graphizer.test.mjs
+++ b/tests/graphizer.test.mjs
@@ -80,6 +80,27 @@ test('resolves tsconfig path aliases and workspace packages across a monorepo', 
   assert(graph.nodes.some(({ id }) => id === 'package:npm:react'));
 });
 
+test('resolves absolute imports against a declared Python source root', () => {
+  const root = mkdtempSync(join(tmpdir(), 'genesis-pyroot-'));
+  mkdirSync(join(root, 'src', 'agents'), { recursive: true });
+  mkdirSync(join(root, 'tests'), { recursive: true });
+  // The src/ layout setuptools documents: packages live under src/, tests import them by bare name.
+  writeFileSync(join(root, 'pyproject.toml'), '[tool.setuptools.packages.find]\nwhere = ["src"]\n');
+  writeFileSync(join(root, 'src', 'agents', '__init__.py'), '');
+  writeFileSync(join(root, 'src', 'agents', 'runner.py'), 'def run():\n    return True\n');
+  writeFileSync(join(root, 'tests', 'test_runner.py'), 'from agents.runner import run\nimport pytest\n');
+
+  const graph = JSON.parse(execFileSync(process.execPath, [graphizer, root], { encoding: 'utf8' }));
+  const edge = (specifier) => graph.edges.find((e) => e.specifier === specifier && e.source === 'file:tests/test_runner.py');
+  assert.equal(edge('agents.runner').target, 'file:src/agents/runner.py', 'declared source root');
+  assert.equal(edge('agents.runner').resolved, true);
+  // The first-party module must not be filed as a package; that is what made impact answer nothing.
+  assert(!graph.nodes.some(({ id }) => id === 'package:pypi:agents'), 'first-party module filed as PyPI package');
+  // A genuine third party still stays external rather than being force-resolved.
+  assert.equal(edge('pytest').resolved, false);
+  assert(graph.nodes.some(({ id }) => id === 'package:pypi:pytest'));
+});
+
 test('extracts top-level declaration kinds without claiming nested ones', () => {
   const root = mkdtempSync(join(tmpdir(), 'genesis-symbols-'));
   mkdirSync(join(root, 'src'), { recursive: true });

--- a/tools/graphizer.mjs
+++ b/tools/graphizer.mjs
@@ -15,12 +15,13 @@ const outPath = resolve(outIndex < 0 ? join(root, '.genesis', 'index', 'graph.js
 const IGNORE = new Set(['.cache', '.genesis', '.git', '.next', '.turbo', '.venv', '__pycache__', 'build', 'coverage', 'dist', 'node_modules', 'out', 'target', 'venv']);
 const CODE = new Set(['.cjs', '.js', '.jsx', '.mjs', '.py', '.ts', '.tsx']);
 const CONFIGS = new Set(['jsconfig.json', 'tsconfig.json']);
+const PY_CONFIGS = new Set(['pyproject.toml', 'setup.cfg']);
 const JS_EXTENSIONS = ['', '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'];
 const NODE_BUILTINS = new Set(builtinModules.map(name => name.replace(/^node:/, '')));
 const hash = value => createHash('sha256').update(value).digest('hex');
 const posix = value => value.split(sep).join('/');
-function walk(dir, files = [], configs = []) { for (const name of readdirSync(dir).sort()) { if (IGNORE.has(name) || name.startsWith('.DS')) continue; const path = join(dir, name); let stat; try { stat = lstatSync(path); } catch { continue; } if (stat.isSymbolicLink()) continue; if (stat.isDirectory()) walk(path, files, configs); else if (CODE.has(extname(name))) files.push(path); else if (CONFIGS.has(name)) configs.push(path); } return { files, configs }; }
-const { files, configs } = walk(root), known = new Set(files), nodes = new Map(), edges = new Map(), warnings = [];
+function walk(dir, files = [], configs = [], pyConfigs = []) { for (const name of readdirSync(dir).sort()) { if (IGNORE.has(name) || name.startsWith('.DS')) continue; const path = join(dir, name); let stat; try { stat = lstatSync(path); } catch { continue; } if (stat.isSymbolicLink()) continue; if (stat.isDirectory()) walk(path, files, configs, pyConfigs); else if (CODE.has(extname(name))) files.push(path); else if (CONFIGS.has(name)) configs.push(path); else if (PY_CONFIGS.has(name)) pyConfigs.push(path); } return { files, configs, pyConfigs }; }
+const { files, configs, pyConfigs } = walk(root), known = new Set(files), nodes = new Map(), edges = new Map(), warnings = [];
 const fileId = path => `file:${posix(relative(root, path))}`;
 const addNode = node => nodes.set(node.id, node);
 // Keyed by a derivable identity so edges dedupe and sort deterministically without storing it.
@@ -126,7 +127,37 @@ function resolveWorkspace(specifier) {
 function packageName(specifier) { const parts = specifier.split('/'); return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]; }
 // undefined means "looked like local source but was not found"; null means "external package".
 function resolveJsImport(from, specifier) { if (specifier.startsWith('.') || specifier.startsWith('/')) return tryCandidates(resolve(dirname(from), specifier)); return resolveAlias(from, specifier) ?? resolveWorkspace(specifier) ?? null; }
-function resolvePythonImport(from, specifier) { const match = specifier.match(/^(\.+)(.*)$/); let base = match ? dirname(from) : root, module = match ? match[2] : specifier; if (match) for (let i = 1; i < match[1].length; i++) base = dirname(base); const path = join(base, ...module.split('.').filter(Boolean)); for (const candidate of [`${path}.py`, join(path, '__init__.py')]) if (known.has(candidate)) return candidate; return match ? undefined : null; }
+// Python has no import map. Under a src/ layout the top-level packages sit one directory below the
+// repository root, so `import agents.x` resolves against <root>/src and not against <root>; read the
+// root a project declares and fall back to the src/ convention. Roots are tried after the repository
+// root, so every edge that resolved before still resolves the same way, and a candidate must already
+// be in the index to win. A source root can therefore turn a wrong package edge into a real file
+// edge; it cannot invent one.
+function declaredPythonRoots(config) {
+  const dir = dirname(config), out = [];
+  let text; try { text = readFileSync(config, 'utf8'); } catch { return out; }
+  if (basename(config) === 'pyproject.toml') {
+    const find = text.match(/\[tool\.setuptools\.packages\.find\]([\s\S]*?)(?=\n\s*\[|$)/);
+    const where = find && find[1].match(/\bwhere\s*=\s*\[([^\]]*)\]/);
+    if (where) for (const value of where[1].matchAll(/["']([^"']+)["']/g)) out.push(join(dir, value[1]));
+    // poetry: packages = [{ include = "pkg", from = "src" }]
+    for (const value of text.matchAll(/\bfrom\s*=\s*["']([^"']+)["']/g)) out.push(join(dir, value[1]));
+  } else {
+    // setup.cfg: package_dir is an indented block whose bare "= src" entry names the root.
+    const block = text.match(/^\s*package_dir\s*=([\s\S]*?)(?=\n\s*\[|\n\S|$)/m);
+    if (block) for (const value of block[1].matchAll(/^\s*=\s*(\S+)\s*$/gm)) out.push(join(dir, value[1]));
+  }
+  return out;
+}
+const pythonRoots = [...new Set([root, ...pyConfigs.flatMap(declaredPythonRoots), join(root, 'src')])]
+  .filter(dir => dir === root || existsSync(dir));
+const knownPython = path => [`${path}.py`, join(path, '__init__.py')].find(candidate => known.has(candidate));
+function resolvePythonImport(from, specifier) {
+  const match = specifier.match(/^(\.+)(.*)$/), parts = (match ? match[2] : specifier).split('.').filter(Boolean);
+  if (match) { let base = dirname(from); for (let i = 1; i < match[1].length; i++) base = dirname(base); return knownPython(join(base, ...parts)); }
+  for (const base of pythonRoots) { const hit = knownPython(join(base, ...parts)); if (hit) return hit; }
+  return null;
+}
 function addDependency(from, specifier, line, language, standard = false) {
   const target = language === 'javascript' ? resolveJsImport(from, specifier) : resolvePythonImport(from, specifier), source = fileId(from), rel = posix(relative(root, from)), extractor = `${language}-imports`;
   const confidence = .85;


### PR DESCRIPTION
Absolute Python imports resolved only against the repository root, so the `src/` layout setuptools documents did not resolve at all. Every first-party import in such a project was filed as a third-party PyPI package and the file edge was never drawn.

This is the Python counterpart of the tsconfig alias and workspace resolution JavaScript gained in 2.4.0.

## Why it matters more than a missing edge

The cost lands on `impact`, which traverses imports. Given a standard layout:

```
pyproject.toml        [tool.setuptools.packages.find] where = ["src"]
src/agents/runner.py
tests/test_runner.py  from agents.runner import run
```

`genesis query . impact src/agents/runner.py` reported **no dependents**, and reported it as success. The graph instead recorded:

```
tests/test_runner.py  ->  package:pypi:agents.runner
```

Empty output from the pre-edit blast-radius check reads as "nothing depends on this file, safe to edit" — the one wrong answer that check must never give. The operating contract, the generated kickoff, the phase instruction in every packet and all five recipes tell an agent to run `impact` before editing shared code, so the failure is silent at exactly the moment the contract asks for trust.

## What this changes

Read the source root a project declares, and fall back to the `src/` convention when it declares none:

| Source | Key |
| --- | --- |
| `pyproject.toml`, setuptools | `[tool.setuptools.packages.find]` → `where` |
| `pyproject.toml`, poetry | `packages = [{ include = ..., from = ... }]` |
| `setup.cfg` | `[options]` → `package_dir` → `= src` |
| no declaration | `src/`, if the directory exists |

Two properties hold the change down:

- **The repository root is tried first.** Every import that resolved before resolves identically, to the same file. The change is strictly additive — it fills gaps, it does not re-point existing edges.
- **A candidate must already be in the index to win.** A source root can only convert a wrong `package:pypi:*` edge into a real file edge; it cannot invent a dependency. A genuine third-party import stays external and unresolved, as before.

Parsing is deliberately narrow and regex-based rather than a TOML dependency, matching the zero-dependency constraint. A declaration it cannot read costs nothing: the `src/` fallback and the existing root behaviour both still apply.

`pyproject.toml` and `setup.cfg` are collected in a separate list during the walk, so they never reach `loadTsconfig`.

## Tests

Added `resolves absolute imports against a declared Python source root`. It builds the layout above and asserts the declared root resolves, that `agents` is **not** filed as a PyPI package, and that a real third party (`pytest`) stays external. Verified it fails before the change and passes after.

No regressions: `resolves tsconfig path aliases and workspace packages across a monorepo` and the rest of `graphizer.test.mjs` still pass, as do `query.test.mjs` and `mcp.test.mjs`.

Unrelated pre-existing Windows failures remain, untouched by this branch: `a failing python3 costs symbols, not whole files`, plus the four `query.test.mjs` CLI tests that #22 addresses. This branch is cut from `main` and is independent of #22 — they can merge in either order. On Windows you need #22 as well to exercise this through the CLI, since `genesis query` prints nothing there without it.

## Verified against a real project

A research repository with a `src/` layout, 12 Python files, `where = ["src"]`. Before, `impact` on two source files returned nothing. After:

```
impact src/agents/random_baseline.py  ->  tests/test_random_smoke.py  file · 1 hop
impact src/envs/mock_env.py           ->  tests/test_random_smoke.py  file · 1 hop
```

`callers` on a class in that project also moved from `ambiguous` to `proven`: with the import binding resolved, the call resolver can name one definition instead of retaining candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Python project analysis to recognize package source roots declared in common project configuration.
  - First-party imports are now correctly resolved to their source files instead of being classified as external packages.
  - Relative imports continue to resolve correctly when matching source files are indexed.
  - Genuine third-party imports remain identified as external and unresolved when no local source is available.
  - Added regression coverage to help prevent these resolution issues from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->